### PR TITLE
Added a link to GoLang client for a new ChatGPT API

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@
 * [GPT-3 Sandbox: Turn ideas into demos in a matter of minutes](https://github.com/shreyashankar/gpt3-sandbox)
 * [gpt-3-experiments by @minimaxir](https://github.com/minimaxir/gpt-3-experiments)
 * [ChatGPT-wrapper: Use it in python and shell](https://github.com/mmabrouk/chatgpt-wrapper)
+* [ChatGPT (GPT-3.5-turbo) API GoLang Client](https://github.com/AlmazDelDiablo/gpt3-5-turbo-go)
 
 ## Products
 * [Tailwind CSS code generator](https://themesberg.com/blog/tailwind-css/gpt-3-tailwind-css-ai-code-generator)

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@
 * [GPT-3 Sandbox: Turn ideas into demos in a matter of minutes](https://github.com/shreyashankar/gpt3-sandbox)
 * [gpt-3-experiments by @minimaxir](https://github.com/minimaxir/gpt-3-experiments)
 * [ChatGPT-wrapper: Use it in python and shell](https://github.com/mmabrouk/chatgpt-wrapper)
-* [ChatGPT (GPT-3.5-turbo) API GoLang Client](https://github.com/AlmazDelDiablo/gpt3-5-turbo-go)
+* [ChatGPT (GPT-3.5-turbo) API Client in Golang](https://github.com/AlmazDelDiablo/gpt3-5-turbo-go)
 
 ## Products
 * [Tailwind CSS code generator](https://themesberg.com/blog/tailwind-css/gpt-3-tailwind-css-ai-code-generator)


### PR DESCRIPTION
OpenAI just released an official API for ChatGPT. So, I created a client for GoLang. 
Official guide: https://platform.openai.com/docs/guides/chat